### PR TITLE
Removendo segundo Header da página de comidas

### DIFF
--- a/src/pages/Foods.js
+++ b/src/pages/Foods.js
@@ -9,7 +9,6 @@ const Foods = () => (
     <Header />
     <SearchBar />
     <RenderFoods />
-    <Header />
     <Footer />
   </div>
 );


### PR DESCRIPTION
Na página de comida estava sendo renderizado dois Headers
![Screenshot from 2020-08-04 11-49-29](https://user-images.githubusercontent.com/24628483/89308550-c471c080-d648-11ea-82ee-9ef23e3bbef0.png)
